### PR TITLE
Moses Options Summary, Node description position

### DIFF
--- a/src/components/service/gene-annotation-service/AnnotationResultVisualizer.js
+++ b/src/components/service/gene-annotation-service/AnnotationResultVisualizer.js
@@ -382,8 +382,8 @@ export default class AnnotationResultVisualizer extends React.Component {
           <div
             style={{
               position: "absolute",
-              top: `${this.state.selectedNode.position.y}px`,
-              left: `${this.state.selectedNode.position.x}px`,
+              bottom: "90px",
+              left: "75px",
               width: "350px",
               backgroundColor: "#c9e1f9",
               border: "solid 1px #87BEF5",

--- a/src/components/service/moses-service/DatasetUpload.js
+++ b/src/components/service/moses-service/DatasetUpload.js
@@ -3,15 +3,13 @@ import { relative } from "path";
 import Dropzone from "react-dropzone";
 import classNames from "classnames";
 import { CloudUpload, Check } from "@material-ui/icons";
-import { showNotification } from "./utils";
 import fileSize from "filesize";
 
 export default class DatasetUpload extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      fileError: false,
-      notification: null
+      fileError: false
     };
   }
   componentDidUpdate() {
@@ -31,10 +29,6 @@ export default class DatasetUpload extends React.Component {
 
     return (
       <div className="datasetUploadWrapper" style={{ width: "100%" }}>
-        {this.state.notification &&
-          showNotification(this.state.notification, () => {
-            this.setState({ notification: null });
-          })}
         <Dropzone
           {...props}
           style={{ marginBottom: "15px" }}

--- a/src/components/service/moses-service/MosesOptionsSummary.js
+++ b/src/components/service/moses-service/MosesOptionsSummary.js
@@ -1,0 +1,58 @@
+import React, { Component, Fragment } from "react";
+import Typography from "@material-ui/core/Typography";
+import Modal from "@material-ui/core/Modal";
+import Table from "@material-ui/core/Table";
+import TableBody from "@material-ui/core/TableBody";
+import TableCell from "@material-ui/core/TableCell";
+import TableHead from "@material-ui/core/TableHead";
+import TableRow from "@material-ui/core/TableRow";
+import Paper from "@material-ui/core/Paper";
+import Button from "@material-ui/core/Button";
+
+export default class MosesOptionsSummary extends Component {
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+    return (
+      <Fragment>
+        <Modal onClose={this.props.onClose} open={this.props.open}>
+          <Paper
+            style={{
+              left: "25%",
+              top: 30,
+              width: "50vw",
+              height: "90vh",
+              padding: "30px",
+              position: "absolute",
+              overflowY: "scroll"
+            }}
+          >
+            <Typography variant="h6" id="modal-title">
+              Moses Options
+            </Typography>
+            <Table>
+              <TableHead>
+                <TableRow>
+                  <TableCell>Moses Option</TableCell>
+                  <TableCell style={{ textAlign: "right" }}>Value</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {this.props.options.map(option => (
+                  <TableRow key={option.name}>
+                    <TableCell component="th" scope="row">
+                      {option.name}
+                    </TableCell>
+                    <TableCell align="right">{option.value}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </Paper>
+        </Modal>
+      </Fragment>
+    );
+  }
+}

--- a/src/components/service/moses-service/MosesServiceForm.js
+++ b/src/components/service/moses-service/MosesServiceForm.js
@@ -12,9 +12,10 @@ import {
   ExpansionPanelSummary,
   ExpansionPanelDetails
 } from "@material-ui/core";
-import { Check } from "@material-ui/icons";
+import { Check, AssignmentOutlined, Clear } from "@material-ui/icons";
 import { MuiThemeProvider, createMuiTheme } from "@material-ui/core/styles";
 import * as utf8 from "utf8";
+import MosesOptionsSummary from "./MosesOptionsSummary";
 
 const Options = {
   DATASET: 0,
@@ -64,7 +65,8 @@ export default class MosesServiceForm extends React.Component {
         mosesOptions: true,
         crossValOptions: true,
         targetFeatureAndFilters: true
-      }
+      },
+      showSummary: false
     };
 
     this.handleInputChange = this.handleInputChange.bind(this);
@@ -283,16 +285,49 @@ export default class MosesServiceForm extends React.Component {
           <Grid item xs={12} style={{ textAlign: "end" }}>
             <Button
               variant="contained"
+              onClick={() => this.setState({ showSummary: true })}
+              style={{ marginLeft: "5px" }}
+            >
+              <AssignmentOutlined style={{ marginRight: "10px" }} />
+              Review Options
+            </Button>
+            <Button
+              variant="contained"
               color="primary"
               onClick={() => this.handleSubmit()}
               disabled={this.props.busy || !this.isValid()}
               style={{ marginLeft: "5px" }}
             >
+              <Check style={{ marginRight: "10px" }} />
               Submit
-              <Check />
             </Button>
           </Grid>
         </Grid>
+
+        <MosesOptionsSummary
+          onClose={() => this.setState({ showSummary: false })}
+          open={this.state.showSummary}
+          options={Object.keys(this.state.mosesOpts)
+            .map(k => ({
+              name: k,
+              value:
+                typeof this.state.mosesOpts[k] === "boolean" ? (
+                  this.state.mosesOpts[k] ? (
+                    <Check />
+                  ) : (
+                    <Clear />
+                  )
+                ) : (
+                  this.state.mosesOpts[k]
+                )
+            }))
+            .concat(
+              Object.keys(this.state.additionalParameters).map(k => ({
+                name: k,
+                value: this.state.additionalParameters[k]
+              }))
+            )}
+        />
       </MuiThemeProvider>
     );
   }


### PR DESCRIPTION
**Changes in this pull request**
- Added a component to show summary of moses options so that the user can check the values before submitting the request.
- Modified the gene-annotation visualizer so that node descriptions appear at the bottom. This change was needed because having the description show up at the same position as the node made it difficult to drag and re-position nodes on the graph.
- Removed showNotification method from DatasetUpload as it is no longer needed there.