### PR TITLE
Handle invalid genes, Decode scheme file before downloading

### DIFF
--- a/src/components/service/GeneAnnotationService.js
+++ b/src/components/service/GeneAnnotationService.js
@@ -114,12 +114,16 @@ export default class GeneAnnotationService extends React.Component {
 
   parseResponse() {
     const { response } = this.props;
-    if (typeof response !== "undefined") {
-      const r = {
-        graph: JSON.parse(response.graph),
-        schemeFile: response.scm
-      };
-      return r;
+    if (response.graph !== "" && response.scm !== "") {
+      if (typeof response !== "undefined") {
+        const r = {
+          graph: JSON.parse(response.graph),
+          schemeFile: response.scm
+        };
+        return r;
+      }
+    } else {
+      return;
     }
   }
 
@@ -301,20 +305,28 @@ export default class GeneAnnotationService extends React.Component {
   }
 
   renderComplete() {
+    const response = this.parseResponse();
     return (
       <React.Fragment>
-        {this.parseResponse().graph.nodes.length < MAXIMUM_GRAPH_SIZE ? (
-          <AnnotationResultVisualizer
-            notification={this.state.notification}
-            annotations={this.state.selectedAnnotations.map(a => a.name)}
-            graph={this.parseResponse().graph}
-            downloadSchemeFile={this.downloadSchemeFile}
-            sliderWidth={this.props.sliderWidth}
-          />
+        {response ? (
+          response.graph.nodes.length < MAXIMUM_GRAPH_SIZE ? (
+            <AnnotationResultVisualizer
+              notification={this.state.notification}
+              annotations={this.state.selectedAnnotations.map(a => a.name)}
+              graph={this.parseResponse().graph}
+              downloadSchemeFile={this.downloadSchemeFile}
+              sliderWidth={this.props.sliderWidth}
+            />
+          ) : (
+            <AnnotationResultDownload
+              downloadSchemeFile={this.downloadSchemeFile}
+            />
+          )
         ) : (
-          <AnnotationResultDownload
-            downloadSchemeFile={this.downloadSchemeFile}
-          />
+          <p>
+            You may have provided invalid gene names. Please make sure you input
+            valid gene names and try again.
+          </p>
         )}
       </React.Fragment>
     );

--- a/src/components/service/GeneAnnotationService.js
+++ b/src/components/service/GeneAnnotationService.js
@@ -225,7 +225,7 @@ export default class GeneAnnotationService extends React.Component {
 
   downloadSchemeFile() {
     const json = `data:application/txt, ${encodeURIComponent(
-      this.parseResponse().schemeFile
+      atob(this.parseResponse().schemeFile)
     )}`;
     const link = document.createElement("a");
     link.setAttribute("href", json);

--- a/src/components/service/gene-annotation-service/AnnotationResultDownload.js
+++ b/src/components/service/gene-annotation-service/AnnotationResultDownload.js
@@ -7,7 +7,7 @@ export default class AnnotationResultDownload extends React.Component {
   render() {
     return (
       <React.Fragment>
-        <Grid containe style={{ paddingTop: "30px" }}>
+        <Grid container style={{ paddingTop: "30px" }}>
           <Grid item style={{ textAlign: "center" }}>
             <img alt="MOZI globe logo" src={logo} style={{ width: "100px" }} />
             <Typography variant="h3" gutterBottom>


### PR DESCRIPTION
**Changes in this PR**
- Decode the scheme file content from base64 before downloading it
- Display a text informing the user if invalid genes had been included in the request. 